### PR TITLE
Added REACT_APP env variable to docker compose file for portal server.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -168,10 +168,11 @@ services:
       context: ../core-management-portal/
     command: yarn start
     environment:
+      - REACT_APP_AUTHORIZATION_ENDPOINT=http://core-authentication-service:8000/login/?next=/openid/authorize/
+      - REACT_APP_CLIENT_ID=management_portal
+      - REACT_APP_LOGIN_CALLBACK=http://core-management-portal:3000/#/oidc/callback?
       - REACT_APP_MANAGEMENT_LAYER=http://core-management-layer:8000
-      - OIDC_RP_CLIENT_ID=client_id_2
       - OIDC_RP_CLIENT_SECRET=super_client_secret_2
-      - OIDC_OP_AUTHORIZATION_ENDPOINT=http://core-authentication-service:8000/openid/authorize/
       - OIDC_OP_TOKEN_ENDPOINT=http://core-authentication-service:8000/openid/token/
       - OIDC_OP_USER_ENDPOINT=http://core-authentication-service:8000/openid/userinfo/
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -168,6 +168,7 @@ services:
       context: ../core-management-portal/
     command: yarn start
     environment:
+      - REACT_APP_MANAGEMENT_LAYER=http://core-management-layer:8000
       - OIDC_RP_CLIENT_ID=client_id_2
       - OIDC_RP_CLIENT_SECRET=super_client_secret_2
       - OIDC_OP_AUTHORIZATION_ENDPOINT=http://core-authentication-service:8000/openid/authorize/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -172,9 +172,6 @@ services:
       - REACT_APP_CLIENT_ID=management_portal
       - REACT_APP_LOGIN_CALLBACK=http://core-management-portal:3000/#/oidc/callback?
       - REACT_APP_MANAGEMENT_LAYER=http://core-management-layer:8000
-      - OIDC_RP_CLIENT_SECRET=super_client_secret_2
-      - OIDC_OP_TOKEN_ENDPOINT=http://core-authentication-service:8000/openid/token/
-      - OIDC_OP_USER_ENDPOINT=http://core-authentication-service:8000/openid/userinfo/
     depends_on:
       - core-authentication-service
     volumes:


### PR DESCRIPTION
Added a REACT_APP_MANAGEMENT_LAYER env variable for the GMP.

*NODE_ENV* is always `development` using `npm start or yarn start` and cannot be overwritten as per the `create-react-app` docs. *NODE_ENV* is `production` when a `npm build` has been run and that build is in use. All environment variables prefixed with `REACT_APP_` are available in the JS app, hence my addition to the compose file below. Please advise if this is suitable or not the way desired.