### PR TITLE
Changes required because of auth service rebase to new container image

### DIFF
--- a/apps/database/docker-entrypoint-initdb.d/init.sql
+++ b/apps/database/docker-entrypoint-initdb.d/init.sql
@@ -12,3 +12,5 @@ CREATE DATABASE wagtail_1;
 
 CREATE USER wagtail_2 PASSWORD 'password';
 CREATE DATABASE wagtail_2;
+
+CREATE EXTENSION pg_trgm;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,8 +62,7 @@ services:
       - ALLOWED_API_KEYS=demo-management-layer-api-key
       - ACCESS_CONTROL_API=http://core-access-control:8080/api/v1
       - USER_DATA_STORE_API=http://core-user-data-store:8080/api/v1
-      - EMAIL_HOST_USER=somedummydata
-      - EMAIL_HOST_PASSWORD=somedummydata
+      - EMAIL_HOST=smtp
       # The varaibles below are not used in production, just the docker-compose env
       - WAGTAIL_1_CALLBACK=http://wagtail-demo-1:8000/oidc/callback/
       - WAGTAIL_2_CALLBACK=http://wagtail-demo-2:8000/oidc/callback/
@@ -71,6 +70,7 @@ services:
       - WAGTAIL_2_LOGOUT_REDIRECT=http://wagtail-demo-2:8000/
     depends_on:
       - db
+      - smtp
     networks:
       - oidcnetwork
 
@@ -83,11 +83,13 @@ services:
     command: celery worker # scripts/waitFor.sh celery -A project worker -l info
     environment:
       - ALLOWED_API_KEYS=demo-management-layer-api-key
+      - DB_DEFAULT=ENGINE=django.db.backends.postgresql,NAME=authentication_service,USER=authentication_service,PASSWORD=password,HOST=db,PORT=5432
       - REDIS_URI=redis://redis:6379/0
       - CELERY_APP=project
       - CELERY_BROKER_URL=redis://redis:6379/0
-      - EMAIL_HOST_USER=somedummydata
-      - EMAIL_HOST_PASSWORD=somedummydata
+      - EMAIL_HOST=smtp
+      # - EMAIL_USER=
+      # - EMAIL_PASSWORD=
       - USER_DATA_STORE_API_KEY=demo-authentication-service-api-key
       - ACCESS_CONTROL_API_KEY=demo-authentication-service-api-key
       - ACCESS_CONTROL_API=http://core-access-control:8080/api/v1
@@ -95,6 +97,7 @@ services:
       - C_FORCE_ROOT=true
     depends_on:
       - db
+      - smtp
     networks:
       - oidcnetwork
 
@@ -244,6 +247,13 @@ services:
       - "3128"
     ports:
       - "${SQUID_PORT}:3128"
+    networks:
+      - oidcnetwork
+
+  smtp:
+    image: "namshi/smtp"
+    expose:
+      - "25"
     networks:
       - oidcnetwork
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,8 @@ services:
       context: ../core-authentication-service/
     volumes:
       - ../core-authentication-service/:/app/
-    command: scripts/waitFor.sh scripts/startDjango.sh
+    command: # scripts/waitFor.sh scripts/startDjango.sh
+    command: project.wsgi:application --threads 5 --timeout 50
     environment:
       - REDIS_URI=redis://redis:6379/0
       # NOTE: we bootstrap our database container with some dbs.
@@ -79,10 +80,11 @@ services:
       context: ../core-authentication-service/
     volumes:
       - ../core-authentication-service/:/app/
-    command: scripts/waitFor.sh celery -A project worker -l info
+    command: celery worker # scripts/waitFor.sh celery -A project worker -l info
     environment:
       - ALLOWED_API_KEYS=demo-management-layer-api-key
       - REDIS_URI=redis://redis:6379/0
+      - CELERY_APP=project
       - CELERY_BROKER_URL=redis://redis:6379/0
       - EMAIL_HOST_USER=somedummydata
       - EMAIL_HOST_PASSWORD=somedummydata

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,10 +90,9 @@ services:
       - EMAIL_HOST=smtp
       # - EMAIL_USER=
       # - EMAIL_PASSWORD=
-      - USER_DATA_STORE_API_KEY=demo-authentication-service-api-key
-      - ACCESS_CONTROL_API_KEY=demo-authentication-service-api-key
-      - ACCESS_CONTROL_API=http://core-access-control:8080/api/v1
-      - USER_DATA_STORE_API=http://core-user-data-store:8080/api/v1
+      # - EMAIL_USE_TLS=
+      # - EMAIL_USE_SSL=
+      # - EMAIL_TIMEOUT=
       - C_FORCE_ROOT=true
     depends_on:
       - db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,7 @@ services:
       - ACCESS_CONTROL_API=http://core-access-control:8080/api/v1
       - USER_DATA_STORE_API=http://core-user-data-store:8080/api/v1
       - EMAIL_HOST=smtp
+      # - SKIP_MIGRATIONS=1  Set this on QA, but not for docker compose.
       # The varaibles below are not used in production, just the docker-compose env
       - WAGTAIL_1_CALLBACK=http://wagtail-demo-1:8000/oidc/callback/
       - WAGTAIL_2_CALLBACK=http://wagtail-demo-2:8000/oidc/callback/
@@ -88,6 +89,7 @@ services:
       - CELERY_APP=project
       - CELERY_BROKER_URL=redis://redis:6379/0
       - EMAIL_HOST=smtp
+      - SKIP_MIGRATIONS=1
       # - EMAIL_USER=
       # - EMAIL_PASSWORD=
       # - EMAIL_USE_TLS=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,7 +95,6 @@ services:
       # - EMAIL_USE_TLS=
       # - EMAIL_USE_SSL=
       # - EMAIL_TIMEOUT=
-      - C_FORCE_ROOT=true
     depends_on:
       - db
       - smtp


### PR DESCRIPTION
* Auth service now uses .org django-bootstrap container as base -- updated `docker-compose.yml` for that.
* Added `smtp` server and adjusted configs accordingly.